### PR TITLE
feat(analytics): page tracking, new projects, ogImage fallback

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,6 +33,11 @@ jobs:
         working-directory: next
         run: npm ci
 
+      - name: Create .env.local
+        working-directory: next
+        run: |
+          echo "NEXT_PUBLIC_INGESTOR_URL=${{ secrets.NEXT_PUBLIC_INGESTOR_URL }}" > .env.local
+
       - name: Build
         working-directory: next
         run: npm run build

--- a/next/app/(home)/_sections/WorksSection.tsx
+++ b/next/app/(home)/_sections/WorksSection.tsx
@@ -78,10 +78,10 @@ function ProjectCard({
   const inView = useInView(ref, { once: true, margin: "-60px" });
   const router = useRouter();
 
-  const hasImage =
-    project.thumbnail &&
-    project.thumbnail !== "/no_image_available.jpg" &&
-    !project.thumbnail.startsWith("/projects/");
+  const imageSrc =
+    project.thumbnail && project.thumbnail !== "/no_image_available.jpg"
+      ? project.thumbnail
+      : project.ogImage ?? null;
 
   return (
     <motion.div
@@ -95,9 +95,9 @@ function ProjectCard({
     >
       {/* Thumbnail */}
       <div className="aspect-video bg-accent overflow-hidden relative">
-        {hasImage ? (
+        {imageSrc ? (
           <Image
-            src={project.thumbnail}
+            src={imageSrc}
             alt={project.title}
             fill
             className="object-cover transition-transform duration-500 group-hover:scale-105"

--- a/next/app/layout.tsx
+++ b/next/app/layout.tsx
@@ -3,6 +3,7 @@ import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import Nav from "@/components/Nav";
 import ThemeInit from "@/components/ThemeInit";
+import PageTracker from "@/components/PageTracker";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -36,6 +37,7 @@ export default function RootLayout({
         className={`${geistSans.variable} ${geistMono.variable} bg-background text-foreground antialiased`}
       >
         <ThemeInit />
+        <PageTracker />
         <Nav />
         {children}
       </body>

--- a/next/components/PageTracker.tsx
+++ b/next/components/PageTracker.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import { useEffect } from "react";
+import { usePathname } from "next/navigation";
+import { trackEvent } from "@/lib/analytics";
+
+export default function PageTracker() {
+  const pathname = usePathname();
+
+  useEffect(() => {
+    trackEvent("page_view");
+  }, [pathname]);
+
+  return null;
+}

--- a/next/data/projects.ts
+++ b/next/data/projects.ts
@@ -14,6 +14,7 @@ export interface Project {
   company?: string;
   stack: string[];
   thumbnail: string;
+  ogImage?: string;
   summary: string;
   metrics?: ProjectMetric[];
   web?: string;
@@ -94,6 +95,56 @@ export const projects: Project[] = [
           "ThemeProvider 기반 전역 테마 관리",
           "Radix UI 기반 접근성 준수 컴포넌트",
           "npm 패키지 배포 (@junseop-shin/my-ui-lib)",
+        ],
+      },
+    ],
+  },
+  {
+    slug: "seobi-chat",
+    type: "personal",
+    title: "서비 챗봇",
+    subtitle: "AI 기반 서비스 안내 챗봇",
+    period: "2026.03 ~",
+    stack: ["Node.js", "WebSocket", "OpenAI API", "PM2"],
+    thumbnail: "/seobi-chat.png",
+    ogImage: "https://seobi.nuclearbomb6518.com",
+    summary: "OpenAI API를 활용한 서비스 안내 챗봇. 실시간 WebSocket 통신으로 대화형 AI 응답 제공.",
+    web: "https://seobi.nuclearbomb6518.com",
+    github: "https://github.com/Junseop-Shin/seobi-chat",
+    sections: [
+      {
+        heading: "주요 특징",
+        items: [
+          "OpenAI API 기반 자연어 처리 및 대화 컨텍스트 유지",
+          "WebSocket 실시간 스트리밍 응답",
+          "Node.js + PM2로 Windows 서버 배포",
+          "Cloudflare Tunnel로 HTTPS 서비스",
+        ],
+      },
+    ],
+  },
+  {
+    slug: "devops-monitor",
+    type: "personal",
+    title: "DevOps Monitor",
+    subtitle: "자체 서비스 통합 옵저버빌리티 플랫폼",
+    period: "2026.03 ~",
+    stack: ["Prometheus", "Grafana", "Loki", "Docker", "TimescaleDB", "Node.js"],
+    thumbnail: "/devops-monitor.png",
+    ogImage: "https://monitoring.nuclearbomb6518.com",
+    summary:
+      "맥미니 + 배포 PC 전체 서비스를 단일 대시보드로 모니터링. 시스템 메트릭, 로그, 유저 이벤트를 Grafana에서 통합 조회.",
+    web: "https://monitoring.nuclearbomb6518.com",
+    github: "https://github.com/Junseop-Shin/devops-monitor",
+    sections: [
+      {
+        heading: "주요 특징",
+        items: [
+          "Prometheus + node_exporter + cAdvisor로 멀티호스트 시스템 메트릭 수집",
+          "Loki + Promtail로 Docker 컨테이너 로그 중앙 집계",
+          "AlertManager → Slack 실시간 알림 (HostDown / HighCPU / HighMemory 등)",
+          "TimescaleDB Hypertable로 유저 이벤트 시계열 저장 및 분석",
+          "Cloudflare Tunnel로 외부 접근, Docker Compose 단일 명령 실행",
         ],
       },
     ],

--- a/next/lib/analytics.ts
+++ b/next/lib/analytics.ts
@@ -1,0 +1,25 @@
+const INGESTOR_URL = process.env.NEXT_PUBLIC_INGESTOR_URL;
+
+export function trackEvent(
+  eventType: string,
+  metadata: Record<string, unknown> = {}
+) {
+  if (!INGESTOR_URL || typeof window === "undefined") return;
+
+  fetch(`${INGESTOR_URL}/v1/events`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      event_type: eventType,
+      service_id: "profile",
+      metadata: {
+        ...metadata,
+        path: window.location.pathname,
+        referrer: document.referrer || undefined,
+        utm_source:
+          new URLSearchParams(window.location.search).get("utm_source") ||
+          undefined,
+      },
+    }),
+  }).catch(() => {});
+}

--- a/next/next.config.ts
+++ b/next/next.config.ts
@@ -13,6 +13,8 @@ const nextConfig: NextConfig = {
     remotePatterns: [
       { protocol: "https", hostname: "lotto.nuclearbomb6518.com" },
       { protocol: "https", hostname: "storybook.nuclearbomb6518.com" },
+      { protocol: "https", hostname: "seobi.nuclearbomb6518.com" },
+      { protocol: "https", hostname: "monitoring.nuclearbomb6518.com" },
     ],
   },
 };


### PR DESCRIPTION
## Summary
- Add `lib/analytics.ts`: `trackEvent()` sends events to Event Ingestor (`NEXT_PUBLIC_INGESTOR_URL`)
- Add `components/PageTracker.tsx`: fires `page_view` event on every route change
- Mount `<PageTracker />` in root layout
- `WorksSection`: use `ogImage` URL as thumbnail fallback when no local image
- `data/projects.ts`: add **seobi-chat** and **devops-monitor** project entries
- `next.config.ts`: allow `seobi.nuclearbomb6518.com` and `monitoring.nuclearbomb6518.com` as remote image hostnames

## Test plan
- [ ] `NEXT_PUBLIC_INGESTOR_URL` set in `.env.local`
- [ ] Page view events appear in TimescaleDB / Grafana user-analytics dashboard
- [ ] seobi-chat and devops-monitor cards visible in Works section
- [ ] ogImage thumbnail loads for cards without local thumbnail

🤖 Generated with [Claude Code](https://claude.com/claude-code)