### PR TITLE
feat(analytics): add anonymous user_id to page_view tracking

### DIFF
--- a/next/lib/analytics.ts
+++ b/next/lib/analytics.ts
@@ -1,5 +1,15 @@
 const INGESTOR_URL = process.env.NEXT_PUBLIC_INGESTOR_URL;
 
+function getAnonymousId(): string {
+  const key = '_aid';
+  let id = localStorage.getItem(key);
+  if (!id) {
+    id = crypto.randomUUID();
+    localStorage.setItem(key, id);
+  }
+  return id;
+}
+
 export function trackEvent(
   eventType: string,
   metadata: Record<string, unknown> = {}
@@ -12,6 +22,7 @@ export function trackEvent(
     body: JSON.stringify({
       event_type: eventType,
       service_id: "profile",
+      user_id: getAnonymousId(),
       metadata: {
         ...metadata,
         path: window.location.pathname,


### PR DESCRIPTION
Use localStorage UUID (_aid) for anonymous user identification