### PR TITLE
feat(projects): 프로젝트 섹션을 제품 단위 메인/서브 2뎁스로 재구성

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,7 @@ dist-ssr
 *.sln
 *.sw?
 .npmrc
+.gstack/
+
+# 서버 접속 정보가 포함된 로컬 인수인계 메모 (public 레포)
+handoff.md

--- a/next/app/(home)/_sections/ProjectGroupBlock.tsx
+++ b/next/app/(home)/_sections/ProjectGroupBlock.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import { useRef } from "react";
+import Link from "next/link";
+import { motion, useInView } from "motion/react";
+import { ArrowRight, ArrowUpRight } from "lucide-react";
+import { findProject, type ProjectGroup } from "@/data/project-groups";
+
+export default function ProjectGroupBlock({
+  group,
+  index,
+}: {
+  group: ProjectGroup;
+  index: number;
+}) {
+  const ref = useRef<HTMLDivElement>(null);
+  const inView = useInView(ref, { once: true, margin: "-60px" });
+  const main = findProject(group.main);
+
+  if (!main) return null;
+
+  return (
+    <motion.div
+      ref={ref}
+      initial={{ opacity: 0, y: 24 }}
+      animate={inView ? { opacity: 1, y: 0 } : {}}
+      transition={{ duration: 0.5, delay: index * 0.08 }}
+      className="bg-card rounded-2xl border border-border overflow-hidden"
+    >
+      {/* Main header */}
+      <div className="p-6">
+        <p className="text-xs text-muted-foreground mb-2">
+          {main.company}
+          {main.company && " · "}
+          {main.period}
+        </p>
+
+        <Link
+          href={`/projects/${main.slug}`}
+          className="group inline-flex items-center gap-1.5"
+        >
+          <h3 className="text-2xl font-bold tracking-tight text-foreground group-hover:text-primary transition-colors">
+            {main.title}
+          </h3>
+          <ArrowUpRight
+            size={18}
+            className="text-muted-foreground group-hover:text-primary group-hover:translate-x-0.5 group-hover:-translate-y-0.5 transition-all"
+          />
+        </Link>
+
+        <p className="text-sm text-muted-foreground mt-1">{main.subtitle}</p>
+
+        <p className="text-sm leading-relaxed text-foreground mt-4">
+          {main.summary}
+        </p>
+
+        {main.metrics && main.metrics.length > 0 && (
+          <div className="flex flex-wrap gap-1.5 mt-4">
+            {main.metrics.map((m) => (
+              <span
+                key={m.label}
+                className="px-2.5 py-0.5 rounded-full text-xs bg-primary/10 text-primary border border-primary/20"
+              >
+                <span className="text-muted-foreground">{m.label}</span>{" "}
+                {m.value}
+              </span>
+            ))}
+          </div>
+        )}
+
+        <div className="flex flex-wrap gap-1.5 mt-2">
+          {main.stack.map((s) => (
+            <span
+              key={s}
+              className="px-2 py-0.5 rounded-full text-xs bg-secondary text-secondary-foreground"
+            >
+              {s}
+            </span>
+          ))}
+        </div>
+      </div>
+
+      {/* Children */}
+      <div className="border-t border-border divide-y divide-border">
+        {group.children.map((child) => {
+          if ("ref" in child) {
+            const sub = findProject(child.ref);
+            if (!sub) return null;
+            return (
+              <Link
+                key={child.ref}
+                href={`/projects/${sub.slug}`}
+                className="group/row flex items-start gap-3 px-6 py-3.5 hover:bg-accent/40 transition-colors"
+              >
+                <ArrowRight
+                  size={14}
+                  className="shrink-0 mt-1 text-primary group-hover/row:translate-x-0.5 transition-transform"
+                />
+                <div className="flex-1 min-w-0">
+                  <div className="flex flex-wrap items-baseline gap-x-2">
+                    <span className="text-sm font-medium text-foreground">
+                      {sub.title}
+                    </span>
+                    <span className="text-xs text-muted-foreground">
+                      {sub.period}
+                    </span>
+                  </div>
+                  <p className="text-xs text-muted-foreground mt-0.5">
+                    {sub.subtitle}
+                  </p>
+                </div>
+              </Link>
+            );
+          }
+
+          return (
+            <div key={child.title} className="flex items-start gap-3 px-6 py-3.5">
+              <span className="shrink-0 mt-2 w-1 h-1 rounded-full bg-muted-foreground" />
+              <div className="flex-1 min-w-0">
+                <div className="flex flex-wrap items-baseline gap-x-2">
+                  <span className="text-sm font-medium text-foreground">
+                    {child.title}
+                  </span>
+                  {child.period && (
+                    <span className="text-xs text-muted-foreground">
+                      {child.period}
+                    </span>
+                  )}
+                </div>
+                <p className="text-xs text-muted-foreground mt-0.5">
+                  {child.note}
+                </p>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </motion.div>
+  );
+}

--- a/next/app/(home)/_sections/TimelineSection.tsx
+++ b/next/app/(home)/_sections/TimelineSection.tsx
@@ -1,8 +1,7 @@
 "use client";
 
-import { useRef, useState } from "react";
-import { motion, useInView, AnimatePresence } from "motion/react";
-import { ChevronDown } from "lucide-react";
+import { useRef } from "react";
+import { motion, useInView } from "motion/react";
 import { career } from "@/data/career";
 import { cn } from "@/lib/utils";
 
@@ -50,8 +49,6 @@ function TimelineItem({
 }) {
   const ref = useRef<HTMLDivElement>(null);
   const inView = useInView(ref, { once: true, margin: "-60px" });
-  const [open, setOpen] = useState(false);
-  const hasTasks = event.tasks && event.tasks.length > 0;
 
   return (
     <motion.div
@@ -71,89 +68,18 @@ function TimelineItem({
         )}
       />
 
-      <div
-        className={cn(
-          "rounded-2xl border border-border bg-card/60 backdrop-blur-sm overflow-hidden",
-          hasTasks && "cursor-pointer"
-        )}
-      >
-        {/* Header */}
-        <button
-          className={cn(
-            "w-full text-left p-5",
-            hasTasks && "hover:bg-accent/30 transition-colors"
-          )}
-          onClick={() => hasTasks && setOpen(!open)}
-          disabled={!hasTasks}
-        >
-          <div className="flex items-start justify-between gap-4">
-            <div className="flex-1">
-              <div className="flex flex-wrap items-baseline gap-2 mb-1">
-                <h3 className="font-semibold text-foreground">{event.company}</h3>
-                <span className="text-sm text-muted-foreground">{event.role}</span>
-              </div>
-              <p className="text-xs text-muted-foreground mb-2">
-                {event.period}
-                {event.duration && ` · ${event.duration}`}
-              </p>
-              <p className="text-sm text-muted-foreground leading-relaxed">
-                {event.summary}
-              </p>
-            </div>
-            {hasTasks && (
-              <motion.div
-                animate={{ rotate: open ? 180 : 0 }}
-                transition={{ duration: 0.3 }}
-                className="shrink-0 mt-1"
-              >
-                <ChevronDown size={16} className="text-muted-foreground" />
-              </motion.div>
-            )}
-          </div>
-        </button>
-
-        {/* Tasks accordion */}
-        <AnimatePresence>
-          {open && event.tasks && (
-            <motion.div
-              initial={{ height: 0, opacity: 0 }}
-              animate={{ height: "auto", opacity: 1 }}
-              exit={{ height: 0, opacity: 0 }}
-              transition={{ duration: 0.35, ease: "easeOut" }}
-            >
-              <div className="border-t border-border px-5 pb-5 pt-4 space-y-5">
-                {event.tasks.map((task, ti) => (
-                  <div key={ti}>
-                    <div className="flex flex-wrap items-baseline gap-2 mb-2">
-                      <h4 className="text-sm font-semibold text-foreground">
-                        {task.title}
-                      </h4>
-                      {task.period && (
-                        <span className="text-xs text-muted-foreground">
-                          {task.period}
-                        </span>
-                      )}
-                    </div>
-                    {task.stack && (
-                      <p className="text-xs text-primary mb-2">{task.stack}</p>
-                    )}
-                    <ul className="space-y-1.5">
-                      {task.items.map((item, ii) => (
-                        <li
-                          key={ii}
-                          className="flex gap-2 text-xs leading-relaxed text-muted-foreground"
-                        >
-                          <span className="mt-1.5 w-1 h-1 rounded-full bg-muted-foreground shrink-0" />
-                          {item}
-                        </li>
-                      ))}
-                    </ul>
-                  </div>
-                ))}
-              </div>
-            </motion.div>
-          )}
-        </AnimatePresence>
+      <div className="rounded-2xl border border-border bg-card/60 backdrop-blur-sm p-5">
+        <div className="flex flex-wrap items-baseline gap-2 mb-1">
+          <h3 className="font-semibold text-foreground">{event.company}</h3>
+          <span className="text-sm text-muted-foreground">{event.role}</span>
+        </div>
+        <p className="text-xs text-muted-foreground mb-2">
+          {event.period}
+          {event.duration && ` · ${event.duration}`}
+        </p>
+        <p className="text-sm text-muted-foreground leading-relaxed">
+          {event.summary}
+        </p>
       </div>
     </motion.div>
   );

--- a/next/app/(home)/_sections/WorksSection.tsx
+++ b/next/app/(home)/_sections/WorksSection.tsx
@@ -1,30 +1,25 @@
 "use client";
 
-import { useRef, useState } from "react";
+import { useRef } from "react";
 import { useRouter } from "next/navigation";
 import { motion, useInView } from "motion/react";
 import Image from "next/image";
 import { ExternalLink, Github, Briefcase, User } from "lucide-react";
-import { projects, type ProjectType } from "@/data/projects";
+import { projects } from "@/data/projects";
+import { projectGroups, groupedSlugs } from "@/data/project-groups";
+import ProjectGroupBlock from "./ProjectGroupBlock";
 import { cn } from "@/lib/utils";
-
-const FILTERS: { label: string; value: ProjectType | "all" }[] = [
-  { label: "전체", value: "all" },
-  { label: "개인", value: "personal" },
-  { label: "업무", value: "work" },
-];
 
 export default function WorksSection() {
   const ref = useRef<HTMLDivElement>(null);
   const inView = useInView(ref, { once: true, margin: "-100px" });
-  const [filter, setFilter] = useState<ProjectType | "all">("all");
 
-  const filtered = (
-    filter === "all" ? projects : projects.filter((p) => p.type === filter)
-  ).slice().sort((a, b) => {
-    const parse = (p: string) => p.slice(0, 7).replace(".", "");
-    return parse(b.period) > parse(a.period) ? 1 : -1;
-  });
+  const standalone = projects
+    .filter((p) => !groupedSlugs.has(p.slug))
+    .sort((a, b) => {
+      const parse = (p: string) => p.slice(0, 7).replace(".", "");
+      return parse(b.period) > parse(a.period) ? 1 : -1;
+    });
 
   return (
     <section id="works" className="py-32 px-6">
@@ -39,30 +34,25 @@ export default function WorksSection() {
           <p className="text-sm font-medium text-primary tracking-widest uppercase mb-3">
             Work
           </p>
-          <h2 className="text-4xl sm:text-5xl font-bold tracking-tight text-foreground mb-8">
+          <h2 className="text-4xl sm:text-5xl font-bold tracking-tight text-foreground">
             프로젝트
           </h2>
-
-          <div className="flex gap-2">
-            {FILTERS.map((f) => (
-              <button
-                key={f.value}
-                onClick={() => setFilter(f.value)}
-                className={cn(
-                  "px-4 py-1.5 rounded-full text-sm font-medium transition-all",
-                  filter === f.value
-                    ? "bg-foreground text-background"
-                    : "bg-accent text-muted-foreground hover:text-foreground"
-                )}
-              >
-                {f.label}
-              </button>
-            ))}
-          </div>
         </motion.div>
 
+        <h3 className="text-lg font-semibold text-foreground mb-5">
+          업무 프로젝트
+        </h3>
+        <div className="space-y-5 mb-16">
+          {projectGroups.map((group, i) => (
+            <ProjectGroupBlock key={group.main} group={group} index={i} />
+          ))}
+        </div>
+
+        <h3 className="text-lg font-semibold text-foreground mb-5">
+          개인 프로젝트
+        </h3>
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-5">
-          {filtered.map((project, i) => (
+          {standalone.map((project, i) => (
             <ProjectCard key={project.slug} project={project} index={i} />
           ))}
         </div>

--- a/next/app/projects/[slug]/ProjectDetailClient.tsx
+++ b/next/app/projects/[slug]/ProjectDetailClient.tsx
@@ -3,14 +3,24 @@
 import { useRef } from "react";
 import Link from "next/link";
 import { motion, useInView } from "motion/react";
-import { ArrowLeft, ExternalLink, Github } from "lucide-react";
+import {
+  ArrowLeft,
+  ArrowUpLeft,
+  ArrowDownRight,
+  ExternalLink,
+  Github,
+} from "lucide-react";
 import type { Project } from "@/data/projects";
+import { findParents, findChildren } from "@/data/project-groups";
 import CountUp from "@/components/react-bits/CountUp";
 import SpotlightCard from "@/components/react-bits/SpotlightCard";
 import GradientText from "@/components/react-bits/GradientText";
 import Particles from "@/components/react-bits/Particles";
 
 export default function ProjectDetailClient({ project }: { project: Project }) {
+  const parents = findParents(project.slug);
+  const subProjects = findChildren(project.slug);
+
   return (
     <div className="min-h-screen pt-14 overflow-hidden relative">
       {/* Particles background */}
@@ -27,21 +37,22 @@ export default function ProjectDetailClient({ project }: { project: Project }) {
       </div>
 
       <div className="max-w-4xl mx-auto px-6 py-16 relative z-10">
-        {/* Back */}
+        {/* 목록으로 — 뎁스와 무관하게 항상 홈 프로젝트 섹션으로 */}
         <motion.div
           initial={{ opacity: 0, x: -10 }}
           animate={{ opacity: 1, x: 0 }}
           transition={{ duration: 0.4 }}
+          className="mb-12"
         >
           <Link
-            href="/"
-            className="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors mb-12 group"
+            href="/#works"
+            className="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors group"
           >
             <ArrowLeft
               size={16}
               className="group-hover:-translate-x-1 transition-transform"
             />
-            뒤로가기
+            프로젝트 목록
           </Link>
         </motion.div>
 
@@ -133,8 +144,95 @@ export default function ProjectDetailClient({ project }: { project: Project }) {
         {project.sections?.map((section, i) => (
           <ContentSection key={i} section={section} delay={0.5 + i * 0.1} />
         ))}
+
+        {/* 뎁스 이동 */}
+        {(parents.length > 0 || subProjects.length > 0) && (
+          <RelatedNav parents={parents} subProjects={subProjects} />
+        )}
       </div>
     </div>
+  );
+}
+
+function RelatedNav({
+  parents,
+  subProjects,
+}: {
+  parents: Project[];
+  subProjects: Project[];
+}) {
+  const ref = useRef<HTMLDivElement>(null);
+  const inView = useInView(ref, { once: true });
+
+  return (
+    <motion.div
+      ref={ref}
+      initial={{ opacity: 0, y: 24 }}
+      animate={inView ? { opacity: 1, y: 0 } : {}}
+      transition={{ duration: 0.6 }}
+      className="mb-6"
+    >
+      <SpotlightCard
+        className="rounded-2xl border border-border bg-card/60 backdrop-blur-md p-6 sm:p-8"
+        spotlightColor="rgba(96, 165, 250, 0.15)"
+      >
+        {parents.length > 0 && (
+          <div className={subProjects.length > 0 ? "mb-8" : undefined}>
+            <h2 className="text-xs font-semibold uppercase tracking-widest text-muted-foreground mb-4">
+              상위 프로젝트
+            </h2>
+            <div className="space-y-2">
+              {parents.map((p) => (
+                <NavRow key={p.slug} project={p} direction="up" />
+              ))}
+            </div>
+          </div>
+        )}
+
+        {subProjects.length > 0 && (
+          <div>
+            <h2 className="text-xs font-semibold uppercase tracking-widest text-muted-foreground mb-4">
+              하위 프로젝트
+            </h2>
+            <div className="space-y-2">
+              {subProjects.map((p) => (
+                <NavRow key={p.slug} project={p} direction="down" />
+              ))}
+            </div>
+          </div>
+        )}
+      </SpotlightCard>
+    </motion.div>
+  );
+}
+
+function NavRow({
+  project,
+  direction,
+}: {
+  project: Project;
+  direction: "up" | "down";
+}) {
+  const Icon = direction === "up" ? ArrowUpLeft : ArrowDownRight;
+
+  return (
+    <Link
+      href={`/projects/${project.slug}`}
+      className="group flex items-start gap-3 rounded-xl border border-border px-4 py-3 hover:border-primary/50 hover:bg-accent/40 transition-colors"
+    >
+      <Icon size={15} className="shrink-0 mt-0.5 text-primary" />
+      <div className="min-w-0">
+        <div className="flex flex-wrap items-baseline gap-x-2">
+          <span className="text-sm font-medium text-foreground group-hover:text-primary transition-colors">
+            {project.title}
+          </span>
+          <span className="text-xs text-muted-foreground">{project.period}</span>
+        </div>
+        <p className="text-xs text-muted-foreground mt-0.5">
+          {project.subtitle}
+        </p>
+      </div>
+    </Link>
   );
 }
 

--- a/next/data/career.ts
+++ b/next/data/career.ts
@@ -5,12 +5,6 @@ export interface CareerEvent {
   duration: string;
   highlight: boolean;
   summary: string;
-  tasks?: {
-    title: string;
-    period?: string;
-    stack?: string;
-    items: string[];
-  }[];
 }
 
 export const career: CareerEvent[] = [
@@ -21,79 +15,7 @@ export const career: CareerEvent[] = [
     duration: "1년",
     highlight: true,
     summary:
-      "SEMS 서비스 유지보수 및 Azure 플랫폼 마이그레이션, CI/CD 자동화, 클라우드 비용 최적화",
-    tasks: [
-      {
-        title: "SEMS 서비스 유지관리",
-        period: "2025.04 ~ 2025.12",
-        stack: "Spring, Java, MariaDB, React, Next.js, TypeScript, Rollbar",
-        items: [
-          "모바일 웹 JSP → React 전환 유지보수",
-          "FCM 최신화 및 배치 처리로 푸시 속도 90% 개선",
-          "Rollbar 모바일 프론트 오류 100% / WAS 오류 80% 제거",
-          "전력량 보정 로직 적용으로 80% 점포 오차 5% 이내 달성",
-          "공통 컴포넌트(서명, 이미지, 헤더 아이콘 등) 구현 및 적용",
-          "기상청 API 오류 대응 및 신규 기능 추가(간판 점검, 해피콜, 양수도 등)",
-        ],
-      },
-      {
-        title: "SEMS 플랫폼 Azure 이관",
-        period: "2025.06 ~ 2026.02",
-        stack:
-          "Spring Boot, Java, Python, PostgreSQL, MongoDB, Azure Servicebus, Azure Function app, MQTT",
-        items: [
-          "MariaDB → PostgreSQL 마이그레이션 (SQL dialect 변환 366개)",
-          "Ncloud bucket → Azure Blob Storage 이관, SAS token 적용",
-          "프로시저 쿼리 개선으로 실행시간 7분 → 20초 (95% 단축)",
-          "수동 배포 → GitHub Actions CI/CD 자동화, pm2 무중단 배포",
-          "기상청·환경공단·알리고 API 연동 및 스테이징 환경 구축",
-          "관제웹 신규 서비스 개발 및 도메인 전환",
-          "설치앱 신규 서비스 개발 및 도메인 전환",
-          "모바일앱 신규 서비스 개발 및 도메인 전환",
-          "기타 외부 연동 API 유지보수",
-        ],
-      },
-      {
-        title: "TnM 플랫폼 위젯 개발",
-        period: "2025.12 ~ 2026.01",
-        stack: "React, TypeScript, react-flow",
-        items: [
-          "커스텀 차트 위젯 개발",
-          "룰체인(react-flow) 위젯 개발",
-          "냉장비 정기점검 AI 연동 대시보드 위젯 개발",
-        ],
-      },
-      {
-        title: "클라우드 비용 절감",
-        period: "2026.01",
-        stack: "Azure, Ncloud",
-        items: [
-          "기존 Ncloud 리소스 정리로 월 약 260만원 절감",
-          "Azure 운영 환경 최적화로 월 약 $742 추가 절감",
-          "logAnalytics, Function apps, VM 최적화 및 미사용 리소스 제거",
-          "GitHub self-hosted runner 적용으로 보안 강화",
-        ],
-      },
-      {
-        title: "팀 협업툴 체계 수립",
-        stack: "Jira, Slack, GitHub, Codex",
-        items: [
-          "비즈니스별 Slack 모니터링/유지보수 채널 구성",
-          "Jira 팀 스페이스 생성, 스프린트 및 자동화 룰 적용",
-          "GitHub 브랜치 관리 룰 및 Codex PR 리뷰 도입",
-        ],
-      },
-      {
-        title: "플랫폼 Task 구조 리팩토링",
-        period: "2026.02",
-        stack: "Java, Python, FastAPI, Azure Monitor",
-        items: [
-          "로깅 정책 통일 (롤링, 포맷, Slack 메시지)",
-          "폴더 구조 개선 및 서버 서비스 FastAPI + Uvicorn 통일",
-          "graceful shutdown 및 Azure Monitor 적용",
-        ],
-      },
-    ],
+      "SEMS 유지보수 및 TnM IoT 플랫폼 이관, CI/CD 자동화, 클라우드 비용 최적화, 플랫폼 v2 재설계",
   },
   {
     company: "주식회사 액스",
@@ -103,35 +25,6 @@ export const career: CareerEvent[] = [
     highlight: true,
     summary:
       "여행 B2B 서비스 신기능 구현 및 TypeScript·디자인시스템 도입. 할당 이슈 180개 중 140개(78%) 해결",
-    tasks: [
-      {
-        title: "제품 안정화",
-        stack: "React, JavaScript, Styled-Components",
-        items: [
-          "백로그 포함 할당 이슈 약 180개 중 78%, 140개 해결",
-          "백로그 제외 전체 해결",
-        ],
-      },
-      {
-        title: "신기능 구현",
-        stack: "React, TypeScript, Styled-Components, SWR, Redux",
-        items: [
-          "계정 계좌/채널/계약 정보 생성·상세·수정 페이지 추가",
-          "상품 판매단위 생성 상세/수정 페이지 추가",
-          "가채널 판매 미리보기 및 비회원 공유용 미리보기 구현",
-        ],
-      },
-      {
-        title: "CI/CD 및 공통 구조",
-        stack: "TypeScript, ESLint, Redux, SWR, date-fns",
-        items: [
-          "TypeScript, ESLint, Prettier 신규 구현부부터 적용",
-          "pre-commit type/lint check 및 PR 빌드 action 추가",
-          "Color, Label, Icon, InputField, Dropdown, Modal 등 디자인 시스템 구축",
-          "Redux, SWR 적용. moment → date-fns 교체",
-        ],
-      },
-    ],
   },
   {
     company: "티맥스가이아",
@@ -141,39 +34,6 @@ export const career: CareerEvent[] = [
     highlight: true,
     summary:
       "웹오피스(포인트/셀/워드) 클립보드·셀렉션 프레임워크 개발 및 CI/CD 구축",
-    tasks: [
-      {
-        title: "웹오피스 클립보드 프레임워크",
-        period: "2022.02 ~ 2023.09",
-        stack: "React, TypeScript, MobX",
-        items: [
-          "오피스 클립보드 포맷 데이터 Object화, sync 보장 및 큐 구조로 리팩토링",
-          "표준 웹 클립보드 API를 이용한 외부 오피스 데이터 호환 프레임워크 구현",
-          "포맷 간 변환 parse/write 구조 및 copy/paste pre/post 프로세스 개선",
-        ],
-      },
-      {
-        title: "웹오피스 셀렉션 프레임워크",
-        period: "2022.06 ~ 2023.09",
-        stack: "React, TypeScript, MobX",
-        items: [
-          "모델 정보 기반 셀렉션 자동생성 리팩토링",
-          "도형·표 등 자체 셀렉션 및 공동 편집 세션별 처리",
-          "중복/불필요 구조 개선 및 전처리/후처리 로직 추가",
-        ],
-      },
-      {
-        title: "웹오피스 클라이언트 CI/CD",
-        period: "2023.02 ~ 2023.09",
-        stack: "Webpack, Jest, React, GitLab",
-        items: [
-          "webpack v4→v5, babel-loader→esbuild-loader 전환으로 빌드 성능 개선",
-          "jest v26→v29 업그레이드, 비동기 mocking으로 테스트 성능 개선",
-          "React v16→v18 마이그레이션 및 전체 패키지 버전 업데이트",
-          "GitLab runner 메모리 제한, husky Node.js 마이그레이션, MR action 속도 개선",
-        ],
-      },
-    ],
   },
   {
     company: "(주)티맥스에이앤씨",
@@ -182,18 +42,6 @@ export const career: CareerEvent[] = [
     duration: "7개월",
     highlight: true,
     summary: "ToHangul 한글 문서 편집기 개발. KERIS에 서비스 제공",
-    tasks: [
-      {
-        title: "ToHangul 개발",
-        stack: "C++, OOXML, MVC 패턴",
-        items: [
-          "쪽 번호 매기기, 머리말꼬리말 편집/템플릿 기능 구현",
-          "인쇄/미리보기/회색조 전체처리(paint vs print), 화면 스케일링",
-          "줄번호 카운팅 및 페인트 기능 구현",
-          "KERIS에 ToHangul 서비스 제공",
-        ],
-      },
-    ],
   },
   {
     company: "한국수력원자력(주)",

--- a/next/data/project-groups.ts
+++ b/next/data/project-groups.ts
@@ -1,0 +1,139 @@
+import { projects, type Project } from "./projects";
+
+/** projects[]의 slug를 참조하는 자식은 링크, 그 외는 텍스트로만 표시된다 */
+export type GroupChild =
+  | { ref: string }
+  | { title: string; period?: string; note: string };
+
+export interface ProjectGroup {
+  main: string;
+  children: GroupChild[];
+}
+
+/** 배열 순서가 곧 화면 노출 순서 (최신 제품 우선) */
+export const projectGroups: ProjectGroup[] = [
+  {
+    main: "platform-v2",
+    children: [{ ref: "platform-v2-redesign" }],
+  },
+  {
+    main: "tnm-platform",
+    children: [
+      { ref: "platform-migration" },
+      { ref: "tnm-widgets" },
+      { ref: "cloud-cost" },
+      {
+        title: "플랫폼 Task 구조 리팩토링",
+        period: "2026.02",
+        note: "로깅 정책 통일, FastAPI + Uvicorn 통일, graceful shutdown 및 Azure Monitor 적용",
+      },
+      {
+        title: "SEMS 정기점검·설치공사 사후점검 기능 추가",
+        period: "2026.05",
+        note: "기사가 완료한 정기점검·설치공사를 무작위 표본으로 뽑아 관리자가 현장에서 재검사하는 감사 기능",
+      },
+    ],
+  },
+  {
+    main: "sems",
+    children: [
+      { ref: "mobile-renewal" },
+      {
+        title: "레거시 유지보수·장애 대응",
+        period: "2025.05 ~ 2026.01",
+        note: "JSP/JS 파일 캐시 문제 쿼리스트링 처리, 기상청 API 오류 대응",
+      },
+      {
+        title: "신규 기능 추가",
+        period: "2025.05 ~ 2026.01",
+        note: "간판 정기점검, 해피콜, 양수도 등",
+      },
+      { ref: "platform-migration" },
+      {
+        title: "전력량 보정",
+        period: "2025.11",
+        note: "보정 로직 적용으로 80% 점포에서 한전 실제 전력량과 오차 5% 이내 달성",
+      },
+      { ref: "mobile-native" },
+    ],
+  },
+  {
+    main: "ax",
+    children: [
+      {
+        title: "제품 안정화",
+        note: "할당 이슈 약 180개 중 140개(78%) 해결, 백로그 제외 전체 해결",
+      },
+      {
+        title: "신기능 구현",
+        note: "계정·상품 관리 페이지 및 가채널 판매 미리보기 구현",
+      },
+      {
+        title: "CI/CD 및 공통 구조",
+        note: "TypeScript·ESLint 도입, 디자인 시스템 구축, Redux·SWR 적용",
+      },
+    ],
+  },
+  {
+    main: "weboffice",
+    children: [
+      {
+        title: "클립보드 프레임워크",
+        period: "2022.02 ~ 2023.09",
+        note: "포맷 데이터 Object화, sync 보장 및 큐 구조 리팩토링, 외부 오피스 데이터 호환",
+      },
+      {
+        title: "셀렉션 프레임워크",
+        period: "2022.06 ~ 2023.09",
+        note: "모델 정보 기반 셀렉션 자동생성, 도형·표 자체 셀렉션 및 공동 편집 세션별 처리",
+      },
+      {
+        title: "클라이언트 CI/CD",
+        period: "2023.02 ~ 2023.09",
+        note: "webpack v4→v5, jest v26→v29, React v16→v18 마이그레이션",
+      },
+    ],
+  },
+  {
+    main: "tohangul",
+    children: [
+      {
+        title: "문서 편집 기능",
+        note: "쪽 번호 매기기, 머리말꼬리말 편집/템플릿, 줄번호 카운팅",
+      },
+      {
+        title: "인쇄·렌더링 처리",
+        note: "인쇄/미리보기/회색조 전체처리(paint vs print), 화면 스케일링",
+      },
+    ],
+  },
+];
+
+export function findProject(slug: string): Project | undefined {
+  return projects.find((p) => p.slug === slug);
+}
+
+/** 메인이거나 어떤 메인의 자식인 slug — 단독 카드 그리드에서 제외된다 */
+export const groupedSlugs = new Set(
+  projectGroups.flatMap((g) => [
+    g.main,
+    ...g.children.flatMap((c) => ("ref" in c ? [c.ref] : [])),
+  ])
+);
+
+/** 라우팅 가능한 하위 프로젝트만 — 텍스트 전용 자식은 이동할 곳이 없어 제외한다 */
+export function findChildren(slug: string): Project[] {
+  const group = projectGroups.find((g) => g.main === slug);
+  if (!group) return [];
+  return group.children
+    .flatMap((c) => ("ref" in c ? [findProject(c.ref)] : []))
+    .filter((p): p is Project => p !== undefined);
+}
+
+/** 한 프로젝트가 여러 메인에 걸칠 수 있어 배열을 반환한다 */
+export function findParents(slug: string): Project[] {
+  return projectGroups
+    .filter((g) => g.children.some((c) => "ref" in c && c.ref === slug))
+    .map((g) => findProject(g.main))
+    .filter((p): p is Project => p !== undefined);
+}

--- a/next/data/projects.ts
+++ b/next/data/projects.ts
@@ -314,7 +314,183 @@ export const projects: Project[] = [
   },
   // ── Work — 티앤엠테크 ─────────────────────────────────────────
   {
+    slug: "sems",
+    type: "work",
+    company: "주식회사 티앤엠테크",
+    title: "SEMS",
+    subtitle: "점포 에너지 관리 서비스",
+    period: "2025.04 ~ 2026.05",
+    stack: [
+      "React",
+      "Next.js",
+      "TypeScript",
+      "Spring",
+      "Java",
+      "PostgreSQL",
+      "Android",
+      "iOS",
+      "FCM",
+    ],
+    thumbnail: "/sems-platform.png",
+    web: "https://platform.atxpert.biz:8443",
+    summary:
+      "모바일 웹·관제웹·설치앱으로 구성된 점포 에너지 관리 서비스. 전환이 중단된 모바일 앱을 인계받아 완성하고 전력량 정확도·장애 대응을 개선한 뒤, Ncloud에 있던 서비스 전체를 TnM IoT 플랫폼으로 이관",
+    metrics: [
+      { label: "FCM 처리 속도", value: "90% 개선" },
+      { label: "모바일 프론트 오류", value: "100% 제거" },
+      { label: "모바일 WAS 오류", value: "80% 제거" },
+      { label: "점포 전력량 오차", value: "5% 이내 달성" },
+    ],
+    sections: [
+      {
+        heading: "서비스 구성",
+        items: [
+          "모바일 웹 — 점포 전력 사용량 조회, 간판 정기점검, 해피콜, 양수도",
+          "관제웹 — 점포 상태 통합 관제",
+          "설치앱 — 현장 설치 및 점검 지원",
+        ],
+      },
+      {
+        heading: "주요 작업",
+        items: [
+          "외주가 만들다 중단한 React 모바일 앱을 인계받아 미연결 기능·잔존 오류를 잡아 완성",
+          "FCM 최신화 및 배치 처리로 푸시 처리 속도 90% 개선",
+          "Rollbar 모니터링 적용으로 모바일 프론트 오류 100% / WAS 오류 80% 제거",
+          "전력량 보정 로직 적용으로 80% 점포에서 한전 실제 전력량과 오차 5% 이내 달성",
+          "JSP/JS 파일 캐시 문제 쿼리스트링 처리, 기상청 API 오류 대응",
+          "간판 정기점검, 해피콜, 양수도 등 신규 기능 추가",
+          "서비스 전체를 TnM IoT 플랫폼으로 이관 — 관제웹·설치앱·모바일앱 API 서버 이전 및 도메인 전환",
+          "모바일 네이티브 개선 — 자동로그인 평문 저장 제거, 네이티브↔웹앱 연동 정비, 앱링크·푸시 토큰 자동 갱신·강제 업데이트 도입",
+        ],
+      },
+    ],
+  },
+  {
+    slug: "mobile-native",
+    type: "work",
+    company: "주식회사 티앤엠테크",
+    title: "모바일 네이티브 개선",
+    subtitle: "인증·네이티브 연동·푸시 체계 정비",
+    period: "2026.04 ~ 2026.05",
+    stack: ["Android", "iOS", "React", "TypeScript", "FCM"],
+    thumbnail: "/mobile-renewal.png",
+    summary:
+      "웹앱을 감싼 네이티브 앱의 인증 방식과 네이티브↔웹앱 연동, 푸시 체계를 전반적으로 정비. 자동로그인 평문 저장 제거, 앱링크 적용, 푸시 토큰 자동 갱신과 로그 추적을 도입",
+    sections: [
+      {
+        heading: "인증·연동 개선",
+        items: [
+          "id/pw를 기기 localStorage에 평문 저장하던 자동로그인 방식 개선",
+          "url param·쿠키·localStorage에 의존하던 네이티브↔웹앱 데이터 전달(deviceType, osVersion, pushToken) 방식 정비",
+        ],
+      },
+      {
+        heading: "푸시 체계 정비",
+        items: [
+          "앱링크 적용으로 푸시 클릭 시 targetUrl 페이지 이동 — 기존에는 원하는 페이지로 이동하지 않았음",
+          "푸시 클릭 후 알림이 리스트에 남던 오류 해결",
+          "푸시 토큰 만료 시 자동 재발급 — 기존에는 앱을 재설치해야만 갱신 가능했음",
+          "FCM 전송 성공 후 미수신 추적이 불가하던 문제를 푸시 로그 적재로 해결",
+        ],
+      },
+      {
+        heading: "배포 대응",
+        items: [
+          "앱 버전 체크 후 강제 업데이트 다이얼로그 및 플레이스토어/앱스토어 이동 도입",
+          "기존 개발 환경과 분리된 모바일 앱 테스트 환경 구축",
+          "신·구앱 iOS/Android 빌드 및 로그인·푸시·강제 업데이트 시나리오 테스트 완료",
+        ],
+      },
+    ],
+  },
+  {
+    slug: "tnm-platform",
+    type: "work",
+    company: "주식회사 티앤엠테크",
+    title: "TnM IoT 플랫폼",
+    subtitle: "사내 IoT 통합 플랫폼",
+    period: "2025.06 ~",
+    stack: [
+      "Spring Boot",
+      "Java",
+      "Python",
+      "FastAPI",
+      "React",
+      "TypeScript",
+      "Azure",
+      "PostgreSQL",
+      "MongoDB",
+    ],
+    thumbnail: "/sems-platform.png",
+    web: "https://platform.atxpert.biz",
+    summary:
+      "여러 비즈니스 서비스를 올려 운영하는 사내 IoT 통합 플랫폼. SEMS를 이 플랫폼으로 이관하고 대시보드 위젯, 운영 구조, 클라우드 비용까지 플랫폼 전반을 정비",
+    metrics: [
+      { label: "Ncloud 리소스", value: "월 830만원 → 125만원" },
+      { label: "Table Storage", value: "월 123만원 → 48만원" },
+      { label: "Azure 운영 환경 최적화", value: "월 $742 추가 절감" },
+      { label: "SQL dialect 변환", value: "366개" },
+    ],
+    sections: [
+      {
+        heading: "주요 작업",
+        items: [
+          "SEMS 서비스 전체를 플랫폼으로 이관 (DB·스토리지 마이그레이션, CI/CD 자동화)",
+          "대시보드 커스텀 위젯 개발 (차트, react-flow 룰체인 편집기, AI 연동)",
+          "Ncloud 정리 및 Azure 리소스 최적화로 운영·개발 환경 비용 절감",
+          "SEMS 사후점검 기능 신규 개발 — 기사가 완료한 정기점검·설치공사를 무작위 표본으로 뽑아 관리자가 현장에서 재검사",
+        ],
+      },
+      {
+        heading: "플랫폼 운영 정비",
+        items: [
+          "로깅 정책 통일 (롤링, 포맷, Slack 메시지)",
+          "폴더 구조 개선 및 서버 서비스 FastAPI + Uvicorn 통일",
+          "graceful shutdown 및 Azure Monitor 적용",
+        ],
+      },
+      {
+        heading: "팀 협업 체계",
+        items: [
+          "비즈니스별 Slack 모니터링/유지보수 채널 구성",
+          "Jira 팀 스페이스 생성, 스프린트 및 자동화 룰 적용",
+          "GitHub 브랜치 관리 룰 및 Codex PR 리뷰 도입",
+        ],
+      },
+    ],
+  },
+  {
     slug: "platform-v2",
+    type: "work",
+    company: "주식회사 티앤엠테크",
+    title: "IoT 플랫폼 v2",
+    subtitle: "서비스별 분리 구조의 차세대 IoT 플랫폼",
+    period: "2026.06 ~",
+    stack: [
+      "Next.js",
+      "TypeScript",
+      "Go",
+      "Kafka",
+      "Azure Event Hubs",
+      "PostgreSQL",
+      "MongoDB",
+    ],
+    thumbnail: "/platform-v2-thumb.png",
+    summary:
+      "여러 서비스가 한 서버에 얽혀 있던 기존 IoT 플랫폼을 서비스별 분리 구조로 다시 세우는 차세대 버전. '플랫폼이지만 결국 SI'라는 전제 위에서 공통 구조 + 분리 빌드·배포 + 기본앱 제공 체계를 목표로 함",
+    sections: [
+      {
+        heading: "설계 방향",
+        items: [
+          "공통 구조 위에 비즈니스별 서비스를 얹는 분리 구조",
+          "서비스별 분리 빌드·배포",
+          "비즈니스 기본앱(웹·모바일) 제공 체계",
+        ],
+      },
+    ],
+  },
+  {
+    slug: "platform-v2-redesign",
     type: "work",
     company: "주식회사 티앤엠테크",
     title: "IoT 플랫폼 v2 재설계",
@@ -331,7 +507,7 @@ export const projects: Project[] = [
     ],
     thumbnail: "/platform-v2-thumb.png",
     summary:
-      "여러 서비스가 한 서버에 얽혀 있던 IoT 플랫폼을 서비스별 분리 구조로 전면 재설계. '플랫폼이지만 결국 SI' 전제 위에서 공통 구조 + 분리 빌드·배포 + 기본앱 제공 체계를 잡고, 프론트엔드와 이벤트 파이프라인을 담당",
+      "멈춰 있던 아키텍처 논의를 정리해 전체 플랜을 수립하고, 프론트엔드와 이벤트 파이프라인을 담당",
     web: "https://github.com/Junseop-Shin/Work/blob/main/Work_History/2026-06-플랫폼-v2-재설계.md",
     sections: [
       {
@@ -350,29 +526,26 @@ export const projects: Project[] = [
     type: "work",
     company: "주식회사 티앤엠테크",
     title: "모바일 앱 리뉴얼",
-    subtitle: "SEMS 모바일 웹 JSP → React 전환 및 안정화",
+    subtitle: "외주 중단된 React 앱을 인계받아 기능 연결 및 안정화",
     period: "2025.04 ~ 2025.12",
     stack: ["React", "Next.js", "TypeScript", "Spring", "Java", "Rollbar"],
     thumbnail: "/mobile-renewal.png",
     web: "https://platform.atxpert.biz:8443",
     summary:
-      "레거시 JSP 모바일 웹을 React로 전환하며 안정성 대폭 개선. FCM 푸시, 오류 모니터링, 전력량 보정 등 핵심 기능 정상화",
+      "JSP 모바일 웹을 React로 전환하다 중단된 외주 결과물을 인계받아, 연결되지 않은 기능과 잔존 오류를 하나씩 잡아가며 완성. FCM 푸시와 오류 모니터링을 정상화해 안정성 확보",
     metrics: [
       { label: "FCM 처리 속도", value: "90% 개선" },
       { label: "모바일 프론트 오류", value: "100% 제거" },
       { label: "모바일 WAS 오류", value: "80% 제거" },
-      { label: "점포 전력량 오차", value: "5% 이내 달성" },
     ],
     sections: [
       {
         heading: "주요 작업",
         items: [
-          "JSP → React 전환 유지보수 및 공통 컴포넌트(서명, 이미지, 헤더 아이콘) 구현",
+          "외주가 만들다 중단한 React/Next 앱 인계 — 미연결 기능과 잔존 오류를 파악해 순차적으로 연결",
+          "공통 컴포넌트(서명, 이미지, 헤더 아이콘) 구현 및 적용",
           "FCM 최신화 및 배치 처리로 푸시 로직 단순화, 처리 속도 90% 개선",
           "Rollbar 모니터링 적용, 모바일 프론트 오류 100% / WAS 오류 80% 제거",
-          "전력량 보정 로직 적용으로 80% 점포 한전 실제 전력량과 오차 5% 이내 달성",
-          "JSP/JS 파일 캐시 문제 쿼리스트링 처리, 기상청 API 오류 대응",
-          "간판 정기점검, 해피콜, 양수도 등 신규 기능 추가",
         ],
       },
     ],
@@ -381,8 +554,8 @@ export const projects: Project[] = [
     slug: "platform-migration",
     type: "work",
     company: "주식회사 티앤엠테크",
-    title: "Azure 플랫폼 이관",
-    subtitle: "SEMS 서비스 Ncloud → Azure 전면 마이그레이션",
+    title: "SEMS → TnM IoT 플랫폼 이관",
+    subtitle: "Ncloud 기반 SEMS를 Azure 위 TnM IoT 플랫폼으로 전면 이관",
     period: "2025.06 ~ 2026.02",
     stack: [
       "Spring Boot",
@@ -397,7 +570,7 @@ export const projects: Project[] = [
     thumbnail: "/sems-platform.png",
     web: "https://platform.atxpert.biz",
     summary:
-      "Ncloud 기반 서비스를 Azure로 전면 이관. DB 마이그레이션, CI/CD 자동화, API 연동까지 풀스택 마이그레이션 수행",
+      "Ncloud에 있던 SEMS 서비스를 Azure 위 TnM IoT 플랫폼으로 전면 이관. DB 마이그레이션, CI/CD 자동화, API 연동까지 풀스택 마이그레이션 수행",
     metrics: [
       { label: "SQL dialect 변환", value: "366개" },
       { label: "프로시저 쿼리 성능", value: "95% 개선 (7분→20초)" },
@@ -432,11 +605,9 @@ export const projects: Project[] = [
         ],
       },
       {
-        heading: "서비스 전환 및 신규 개발",
+        heading: "서비스 전환",
         items: [
-          "관제웹 신규 서비스 개발 및 도메인 전환",
-          "설치앱 신규 서비스 개발 및 도메인 전환",
-          "모바일앱 신규 서비스 개발 및 도메인 전환",
+          "관제웹·설치앱·모바일앱 API 서버 이전 및 도메인 전환",
           "기타 외부 연동 API 유지보수",
         ],
       },
@@ -447,22 +618,43 @@ export const projects: Project[] = [
     type: "work",
     company: "주식회사 티앤엠테크",
     title: "클라우드 비용 절감",
-    subtitle: "Ncloud 정리 및 Azure 리소스 최적화",
-    period: "2026.01",
-    stack: ["Azure", "Ncloud", "GitHub Actions"],
+    subtitle: "Ncloud 정리 · Azure 리소스 및 스토리지 최적화",
+    period: "2026.01 ~ 2026.07",
+    stack: [
+      "Azure",
+      "Azure Data Factory",
+      "Blob Storage",
+      "Ncloud",
+      "GitHub Actions",
+    ],
     thumbnail: "/cloud-cost.svg",
     summary:
-      "불필요한 클라우드 리소스를 분석하고 최적화해 운영·개발 환경 모두에서 비용을 대폭 절감",
+      "불필요한 클라우드 리소스를 분석·정리하고, 계속 증가하던 스토리지 비용을 압축 아카이빙 파이프라인으로 고정비화. 운영·개발 환경 모두에서 비용을 대폭 절감",
     metrics: [
-      { label: "Ncloud 리소스 정리", value: "월 260만원 절감" },
+      { label: "Ncloud 리소스", value: "월 830만원 → 125만원" },
+      { label: "Table Storage", value: "월 123만원 → 48만원" },
       { label: "Azure 운영 환경 최적화", value: "월 $742 추가 절감" },
     ],
     sections: [
       {
-        heading: "주요 작업",
+        heading: "Ncloud 리소스 정리",
         items: [
           "SEMS 기존 Ncloud 리소스 사용 현황 파악 및 Azure 이관으로 불필요 리소스 정리 (VM, 로드밸런서, DB 가용성 해제 등)",
-          "Azure logAnalytics, Function apps 설정 변경 및 VM 대체로 운영 환경 월 $742 절감",
+          "플랫폼 이관 완료 후 미이관 서비스를 제외한 전 리소스 정리 — 월 830만원 → 125만원",
+        ],
+      },
+      {
+        heading: "Table Storage 아카이빙 이관",
+        items: [
+          "계속 증가하던 Table Storage 비용에 대응 — 최근 3개월치만 남기고 나머지는 Blob Storage에 압축 저장",
+          "Azure Data Factory 파이프라인을 구성해 이관 자동화",
+          "월 123만원(증가 추세) → 48만원(고정) — 일회성 마이그레이션 비용 92만원은 약 1.2개월 만에 회수",
+        ],
+      },
+      {
+        heading: "Azure 리소스 최적화",
+        items: [
+          "Azure logAnalytics, Function apps 설정 변경 및 VM 대체로 운영 환경 월 $742 절감 (당시 USD 청구 기준, 이후 원화 청구로 전환)",
           "미사용 VM 제거, ServiceBus/PostgreSQL server/MongoDB disk 성능 최적화",
           "GitHub self-hosted runner 적용으로 보안 강화 및 운영 서비스 배포환경 네트워크 inbound 규칙 적용",
         ],
@@ -510,13 +702,27 @@ export const projects: Project[] = [
     ],
     sections: [
       {
-        heading: "주요 작업",
+        heading: "제품 안정화",
+        items: [
+          "백로그 포함 할당 이슈 약 180개 중 78%, 140개 해결",
+          "백로그 제외 전체 해결",
+        ],
+      },
+      {
+        heading: "신기능 구현",
         items: [
           "계정 계좌/채널/계약 정보 생성·상세·수정 페이지 추가",
-          "상품 판매단위 생성 및 가채널 판매 미리보기 구현",
+          "상품 판매단위 생성 상세/수정 페이지 추가",
+          "가채널 판매 미리보기 및 비회원 공유용 미리보기 구현",
+        ],
+      },
+      {
+        heading: "CI/CD 및 공통 구조",
+        items: [
           "TypeScript, ESLint, Prettier 신규 구현부부터 적용",
+          "pre-commit type/lint check 및 PR 빌드 action 추가",
           "Color, Label, Icon, InputField, Dropdown, Modal 등 디자인 시스템 구축",
-          "Redux, SWR 상태관리 적용. moment → date-fns 교체",
+          "Redux, SWR 적용. moment → date-fns 교체",
         ],
       },
     ],
@@ -572,12 +778,18 @@ export const projects: Project[] = [
       "ToHangul 한글 문서 편집기 핵심 기능 구현. KERIS(한국교육학술정보원) 서비스 제공",
     sections: [
       {
-        heading: "주요 구현",
+        heading: "문서 편집 기능",
         items: [
-          "쪽 번호 매기기, 머리말꼬리말 편집/템플릿 기능",
-          "인쇄/미리보기/회색조 전체처리 (paint vs print), 화면 스케일링",
-          "줄번호 카운팅 및 페인트 기능",
-          "KERIS에 ToHangul 서비스 제공",
+          "쪽 번호 매기기 기능 구현",
+          "머리말꼬리말 편집 및 템플릿 기능 구현",
+          "줄번호 카운팅 및 페인트 기능 구현",
+        ],
+      },
+      {
+        heading: "인쇄·렌더링 처리",
+        items: [
+          "인쇄/미리보기/회색조 전체처리 (paint vs print)",
+          "화면 스케일링 처리",
         ],
       },
     ],

--- a/next/tsconfig.json
+++ b/next/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "ES2017",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -11,7 +15,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "incremental": true,
     "plugins": [
       {
@@ -19,9 +23,19 @@
       }
     ],
     "paths": {
-      "@/*": ["./*"]
+      "@/*": [
+        "./*"
+      ]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
## 배경

프로젝트 섹션이 필터 + 카드 16장 평면 그리드였습니다. 두 가지 문제가 있었습니다.

1. **서사가 흩어졌습니다.** 티앤엠테크 업무 5건은 사실 SEMS / TnM IoT 플랫폼 / IoT 플랫폼 v2 세 제품에 대한 작업인데, 카드가 동등하게 나열돼 각각 작은 단발 업무로 보였습니다. `7분→20초`, `830→125만원`, `오류 100% 제거` 같은 성과가 카드마다 흩어져 "한 제품을 오래 끌고 갔다"는 사실이 읽히지 않았습니다.
2. **이력 섹션과 중복이었습니다.** `TimelineSection`의 tasks 아코디언이 프로젝트 카드와 거의 1:1로 겹쳐, 같은 글이 한 페이지에 두 번 나왔습니다.

## 구조

깊이는 토글이 아니라 **라우팅**으로 표현합니다. 메인·서브 각각 상세 페이지를 갖습니다.

```
홈 · 프로젝트 섹션
├ 업무 프로젝트          ← 메인 블록 6개
│  ├ IoT 플랫폼 v2         → IoT 플랫폼 v2 재설계
│  ├ TnM IoT 플랫폼        → 이관 · 위젯 · 비용절감 + 텍스트 항목 2개
│  ├ SEMS                 → 모바일 리뉴얼 · 이관 · 네이티브 개선 + 텍스트 항목 2개
│  ├ 여행 B2B 서비스 / 웹오피스 / ToHangul
└ 개인 프로젝트          ← 기존 카드 그리드 10장
```

**메인도 평범한 `Project`로 뒀습니다.** 상세 페이지·메타데이터·OG 이미지가 전부 `projects.find(slug)` 하나에 매달려 있어, 메인을 별도 타입으로 만들면 세 곳을 분기시켜야 했습니다. "메인 → 자식" 매핑만 `data/project-groups.ts`로 분리해 신규 코드를 최소화했습니다.

자식은 두 형태뿐입니다.

| 형태 | 렌더 |
|---|---|
| `{ ref: "slug" }` | 제목·기간·요약을 `projects`에서 끌어와 링크 |
| `{ title, period?, note }` | 텍스트만, 링크 없음 |

`SEMS → TnM IoT 플랫폼 이관`처럼 한 프로젝트가 여러 메인에 걸칠 수 있어 "메인이 자식 목록을 갖는" 방향으로 매핑했습니다.

## 주요 변경

- 필터(전체/개인/업무) 제거 — 업무는 블록, 개인은 그리드로 이미 분리돼 할 일이 없어졌습니다
- 상세 페이지 상단에 뎁스와 무관하게 항상 `← 프로젝트 목록`, 하단에 `상위/하위 프로젝트` 이동 블록
- `career.ts`의 `tasks` 필드 제거 및 이력 섹션 아코디언 평탄화 — 내용은 전부 프로젝트 쪽으로 이관 완료
- 신규 상세 페이지 4개: `sems`, `tnm-platform`, `platform-v2-redesign`, `mobile-native`

## 내용 정정

- **모바일 앱 리뉴얼** — "JSP → React 전환"으로 쓰여 있어 전환을 직접 수행한 것처럼 읽혔습니다. 실제로는 외주가 만들다 중단한 React/Next 앱을 인계받아 미연결 기능과 잔존 오류를 잡은 작업이라 다시 썼습니다
- **이관 프로젝트** — "관제웹/설치앱/모바일앱 신규 서비스 개발"을 실제 작업인 API 서버 이전으로 정정
- **클라우드 비용** — 기존 `260만원 절감`은 `830 → 125만원`에 포함된 수치라 통합. Table Storage 아카이빙 이관(Azure Data Factory, 월 123 → 48만원, 일회성 92만원 약 1.2개월 회수) 추가

## 검증

- `npx tsc --noEmit` 통과
- `npm run lint` 에러 0 (경고 2건은 `react-bits` 기존 것)
- `npm run build` 성공 — SSG 경로 18 → 20개
- 브레드크럼: `platform-migration` → 상위 2개, `sems` → 하위 3개, `techfeed` → 목록 링크만
- 375px 가로 오버플로 없음, 다크/라이트 모드 확인

## 남은 것

`sems`·`tnm-platform` 상세 페이지 본문은 기존 데이터를 재조합한 초안이라 실제 맥락 보완이 필요합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)